### PR TITLE
Update test workflow to verify exercises

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,4 @@
-# This workflow will do a clean install of the dependencies and run tests across different versions
-#
-# Replace <track> with the track name
-# Replace <image-name> with an image to run the jobs on
-# Replace <action to setup tooling> with a github action to setup tooling on the image
-# Replace <install dependencies> with a cli command to install the dependencies
-#
-# Find Github Actions to setup tooling here:
-# - https://github.com/actions/?q=setup&type=&language=
-# - https://github.com/actions/starter-workflows/tree/main/ci
-# - https://github.com/marketplace?type=actions&query=setup
-#
-# Requires scripts:
-# - bin/test
-
-name: <track> / Test
+name: Test
 
 on:
   push:
@@ -23,17 +8,11 @@ on:
 
 jobs:
   ci:
-    runs-on: <image-name>
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Use <setup tooling>
-        uses: <action to setup tooling>
-
-      - name: Install project dependencies
-        run: <install dependencies>
 
       - name: Run tests for all exercises
         run: bin/test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bin/configlet
 bin/configlet.exe
 .unisonHistory
 **/testLoader.output.md
+*.u.bak
+results.json

--- a/bin/test
+++ b/bin/test
@@ -1,28 +1,58 @@
 #!/usr/bin/env bash
 
-# Synopsis:
-# Test the track's exercises.
-# 
-# At a minimum, this file must check if the example/exemplar solution of each 
+# Test if the example/exemplar solution of each 
 # Practice/Concept Exercise passes the exercise's tests.
-#
-# To check this, you usually have to (temporarily) replace the exercise's solution files
-# with its exemplar/example files.
-#
-# If your track uses skipped tests, make sure to (temporarily) enable these tests
-# before running the tests.
-#
-# The path to the solution/example/exemplar files can be found in the exercise's
-# .meta/config.json file, or possibly inferred from the exercise's directory name.
 
 # Example:
 # ./bin/test
+
+set -eo pipefail
+
+docker pull exercism/unison-test-runner
+
+exit_code=0
+
+function run_test_runner() {
+    local dir=$1
+    local slug=$2
+
+    docker run \
+        --rm \
+        --network none \
+        --mount type=bind,src="${dir}",dst=/solution \
+        --mount type=bind,src="${dir}",dst=/output \
+        --tmpfs /tmp:rw \
+        exercism/unison-test-runner "${slug}" "/solution" "/output"
+}
+
+function verify_exercise() {
+    local dir=$(realpath $1)
+    local slug=$(basename "${dir}")
+    local implementation_file_key=$2    
+    local implementation_file=$(jq -r --arg d "${dir}" --arg k "${implementation_file_key}" '$d + "/" + .files[$k][0]' "${dir}/.meta/config.json")
+    local stub_file=$(jq -r --arg d "${dir}" '$d + "/" + .files.solution[0]' "${dir}/.meta/config.json")
+    local stub_backup_file="${stub_file}.bak"
+    local results_file="${dir}/results.json"
+
+    cp "${stub_file}" "${stub_backup_file}"
+    cp "${implementation_file}" "${stub_file}"
+
+    run_test_runner "${dir}" "${slug}"
+
+    if [[ $(jq -r '.status' "${results_file}") != "pass" ]]; then
+        echo "${slug}: ${implementation_file_key} solution did not pass the tests"
+        exit_code=1
+    fi
+
+    mv "${stub_backup_file}" "${stub_file}"
+    rm -f "${results_file}"
+}
 
 # Verify the Concept Exercises
 for concept_exercise_dir in ./exercises/concept/*/; do
     if [ -d $concept_exercise_dir ]; then
         echo "Checking $(basename "${concept_exercise_dir}") exercise..."
-        # TODO: run command to verify that the exemplar solution passes the tests
+        verify_exercise $concept_exercise_dir "exemplar"
     fi
 done
 
@@ -30,6 +60,8 @@ done
 for practice_exercise_dir in ./exercises/practice/*/; do
     if [ -d $practice_exercise_dir ]; then
         echo "Checking $(basename "${practice_exercise_dir}") exercise..."
-        # TODO: run command to verify that the example solution passes the tests
+        verify_exercise $practice_exercise_dir "example"
     fi
 done
+
+exit ${exit_code}


### PR DESCRIPTION
The test GHA workflow calls the bin/test script, which iterates over all concept and practice exercise and verifies their implementation.

I've implemented this to also allow the `bin/test` script to run locally, provided Docker and jq are installed.