### PR TITLE
Fix inline item on track test docs

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -21,7 +21,8 @@
   1. With the UCM watching the exercise directory, make your changes in the `<myFileName>.u` file
   2. Save the `<myFileName>.u` file
   3. If the file typechecks, run the `add` or `update` UCM commands
-    * If the file does not typecheck, make changes to the code in your `<myFileName>.u` file until it compiles
+
+     * If the file does not typecheck, make changes to the code in your `<myFileName>.u` file until it compiles
   4. Run the `load <myFileName>.test.u` command in the UCM cli to bring the tests into scope and run them
 
   ### Detailed walk through


### PR DESCRIPTION
Small fix for this item that I don't think it's meant to be inlined:

<img width="804" alt="image" src="https://user-images.githubusercontent.com/6928620/175768528-36d0d327-3aa1-4457-a22e-2342331c24d2.png">

How the fix looks like using the VSCode previewer:

<img width="462" alt="image" src="https://user-images.githubusercontent.com/6928620/175768585-d328eda5-d6e0-4b75-9557-6a031ce4c240.png">
