### PR TITLE
Sort results for `list` in `allergies` tests

### DIFF
--- a/exercises/practice/allergies/allergies.test.u
+++ b/exercises/practice/allergies/allergies.test.u
@@ -1,3 +1,6 @@
+toSorted : [a] -> [a]
+toSorted xs = List.sortBy id xs
+
 allergies.test.ex1 = let
 	test.label "not allergic to anything" <| test.expect (allergicTo "eggs" 0 === false)
 
@@ -131,19 +134,19 @@ allergies.test.ex44 = let
 	test.label "just strawberries" <| test.expect (list 8 === ["strawberries"])
 
 allergies.test.ex45 = let
-	test.label "eggs and peanuts" <| test.expect (list 3 === ["eggs","peanuts"])
+	test.label "eggs and peanuts" <| test.expect (toSorted (list 3) === toSorted ["eggs","peanuts"])
 
 allergies.test.ex46 = let
-	test.label "more than eggs but not peanuts" <| test.expect (list 5 === ["eggs","shellfish"])
+	test.label "more than eggs but not peanuts" <| test.expect (toSorted (list 5) === toSorted ["eggs","shellfish"])
 
 allergies.test.ex47 = let
-	test.label "lots of stuff" <| test.expect (list 248 === ["strawberries","tomatoes","chocolate","pollen","cats"])
+	test.label "lots of stuff" <| test.expect (toSorted (list 248) === toSorted ["strawberries","tomatoes","chocolate","pollen","cats"])
 
 allergies.test.ex48 = let
-	test.label "everything" <| test.expect (list 255 === ["eggs","peanuts","shellfish","strawberries","tomatoes","chocolate","pollen","cats"])
+	test.label "everything" <| test.expect (toSorted (list 255) === toSorted ["eggs","peanuts","shellfish","strawberries","tomatoes","chocolate","pollen","cats"])
 
 allergies.test.ex49 = let
-	test.label "no allergen score parts" <| test.expect (list 509 === ["eggs","shellfish","strawberries","tomatoes","chocolate","pollen","cats"])
+	test.label "no allergen score parts" <| test.expect (toSorted (list 509) === toSorted ["eggs","shellfish","strawberries","tomatoes","chocolate","pollen","cats"])
 
 allergies.test.ex50 = let
 	test.label "no allergen score parts without highest valid score" <| test.expect (list 257 === ["eggs"])


### PR DESCRIPTION
[My first solution](https://exercism.org/tracks/unison/exercises/allergies/solutions/brianloveswords) for this problem ended up failing when I produced the right results, but in the wrong order!

If I think about the problem domain, I'm not sure the ordering of the list of allergens is important—`["eggs", "peanuts"]` and `["peanuts", "eggs"]` represent semantically equivalent answers to the question "what set of allergies does this score represent?"

Sorting the results in the tests will open this up to more correct (IMO) solutions, so I put together this PR that does that!

I ran `bin/test` and everything seemed to go (but I'm not sure I understand the output), and I also tested locally against [runarorama's solution](https://exercism.org/tracks/unison/exercises/allergies/solutions/runarorama) and [stew's solution](https://exercism.org/tracks/unison/exercises/allergies/solutions/stew) to make sure they still pass and they do.