### PR TITLE
updates to majority element to ensure name disambiguation.

### DIFF
--- a/exercises/practice/majority-element/.docs/instructions.append.md
+++ b/exercises/practice/majority-element/.docs/instructions.append.md
@@ -2,7 +2,7 @@
 
 - Bonus points: can you generalize your implementation to find the majority element of any type of List?
 - Bonus points: is your implementation performant if there are many different elements to choose from when finding the majority?
-- While you can implement the `majorityFinder` function in any way you choose, we've provided a few stubs which use the `Store` ability. You'll need to implement the `runWith` handler if you choose to use this ability. `runWith` returns both the result of running the function which uses the `Store` ability and the final state of the `Store`.
+- While you can implement the `majorityFinder` function in any way you choose, we've provided a few stubs which use the `MyStore` ability. (The `MyStore` ability is the same as `Store` from the standard library, but here we've given it a slightly different name for disambiguation.) You'll need to implement the `runWith` handler if you choose to use this ability. `runWith` returns both the result of running the function which uses the `MyStore` ability and the final state of the `MyStore`.
 - You can read more about how ability handlers can track state in [the ability handler documentation][ability-handler-docs].
 
 [ability-handler-docs]: https://www.unisonweb.org/docs/abilities#creating-and-handling-abilities

--- a/exercises/practice/majority-element/.meta/examples/majorityElement.example.u
+++ b/exercises/practice/majority-element/.meta/examples/majorityElement.example.u
@@ -1,38 +1,37 @@
-unique type Color = Red | Orange | Yellow | Green | Blue | Purple
+unique type majorityElement.Color = Red | Orange | Yellow | Green | Blue | Purple
 
-majorityFinder : [Color] -> Optional Color
-majorityFinder colors =
+majorityElement.majorityFinder : [Color] -> Optional Color
+majorityElement.majorityFinder colors =
   res _ = List.map (c -> !(update c)) colors
-  (Counter colorTup, r) = Store.runWith (Counter None) res
+  (Counter colorTup, r) = MyStore.runWith (Counter None) res
   Optional.flatMap (cases (_, candidate) -> let
       count = List.filter (elem -> elem === candidate) colors |> List.size
       if count > ((List.size colors) / 2) then Some candidate else None
     ) colorTup
 
+structural ability majorityElement.MyStore a where
+  put : a ->{majorityElement.MyStore a} ()
+  get : {majorityElement.MyStore a} a
 
-structural ability Store where
-  put : a ->{Store a} ()
-  get : {Store a} a
-
-Store.runWith : a -> '{Store a, g} r -> {g} (a, r)
-Store.runWith elem storeFunction =
+majorityElement.MyStore.runWith : a -> '{MyStore a, g} r -> {g} (a, r)
+majorityElement.MyStore.runWith elem storeFunction =
   impl a = cases
     {pure} -> (a, pure)
-    {Store.get -> resume } -> handle resume a with impl a
-    {Store.put aa -> resume} -> handle resume () with impl aa
+    {MyStore.get -> resume } -> handle resume a with impl a
+    {MyStore.put aa -> resume} -> handle resume () with impl aa
   handle !storeFunction with impl elem
 
 unique type StoredState a = Counter (Optional (Nat, a))
 
-update : a -> '{Store (StoredState a)} ()
-update newElem _ =
-  match Store.get with
+majorityElement.update : a -> '{MyStore (StoredState a)} ()
+majorityElement.update newElem _ =
+  match MyStore.get with
     Counter None ->
-      Store.put (Counter (Some (1, newElem)))
+      MyStore.put (Counter (Some (1, newElem)))
     Counter (Some (count, currentElem)) | newElem === currentElem ->
-      Store.put (Counter (Some ((count + 1), currentElem)))
+      MyStore.put (Counter (Some ((count + 1), currentElem)))
     Counter (Some (count, currentElem)) | count === 0 ->
-      Store.put  ( Counter (Some (1, newElem)))
+      MyStore.put  ( Counter (Some (1, newElem)))
     Counter (Some (count, currentElem)) ->
-      Store.put (Counter (Some ((count - 1), currentElem)))
+      MyStore.put (Counter (Some ((count - 1), currentElem)))
 

--- a/exercises/practice/majority-element/majorityElement.test.u
+++ b/exercises/practice/majority-element/majorityElement.test.u
@@ -1,3 +1,5 @@
+use majorityElement.Color
+
 majorityElement.test.ex1 = let
   Test.label "should find the simple majority in a list" <| Test.expect (majorityFinder [Red, Blue, Red, Red, Yellow] === (Some Red))
 

--- a/exercises/practice/majority-element/majorityElement.u
+++ b/exercises/practice/majority-element/majorityElement.u
@@ -1,20 +1,19 @@
 unique type majorityElement.Color = Red | Orange | Yellow | Green | Blue | Purple
 
 majorityElement.majorityFinder : [Color] -> Optional Color
-majorityElement.majorityFinder words =
+majorityElement.majorityFinder colors =
   todo "implement majorityFinder"
 
+structural ability majorityElement.MyStore a where
+  put : a ->{majorityElement.MyStore a} ()
+  get : {majorityElement.MyStore a} a
 
-structural ability majorityElement.Store where
-  put : a ->{Store a} ()
-  get : {Store a} a
-
-majorityElement.Store.runWith : a -> '{Store a, g} r -> {g} (a, r)
-majorityElement.Store.runWith elem storeFunction =
-  todo "optionally implement runWith handler if you choose to use the Store ability"
+majorityElement.MyStore.runWith : a -> '{MyStore a, g} r -> {g} (a, r)
+majorityElement.MyStore.runWith elem storeFunction =
+  todo "optionally implement runWith handler if you choose to use the MyStore ability"
 
 unique type majorityElement.StoredState = Placeholder
 
-majorityElement.update : a -> '{Store StoredState} ()
+majorityElement.update : a -> '{MyStore StoredState} ()
 majorityElement.update currentElement _ =
   todo "optionally implement update"


### PR DESCRIPTION
We had an issue where some imports weren't being disambiguated in the test file. I also changed the `Store` name to conflict less with the standard library. 