### PR TITLE
etl: use `==` for Map comparison in tests

### DIFF
--- a/exercises/practice/etl/etl.test.u
+++ b/exercises/practice/etl/etl.test.u
@@ -1,7 +1,7 @@
 etl.test.ex1 = let  
   lettersByScore = [(1, [?A])] |> Map.fromList
   expected = [(?a, 1)] |> Map.fromList
-  Test.label "Single letter" <| Test.expect (transform lettersByScore === expected)
+  Test.label "Single letter" <| Test.expect (transform lettersByScore == expected)
 
 etl.test.ex2 = let
   lettersByScore = [(1, [?A, ?E, ?I, ?O, ?U])] |> Map.fromList
@@ -11,7 +11,7 @@ etl.test.ex2 = let
       (?i, 1),
       (?o, 1),
       (?u, 1) ] |> Map.fromList
-  Test.label "Single score with multiple letters" <| Test.expect (transform lettersByScore === expected)
+  Test.label "Single score with multiple letters" <| Test.expect (transform lettersByScore == expected)
 
 etl.test.ex3 = let  
   lettersByScore = 
@@ -22,7 +22,7 @@ etl.test.ex3 = let
       (?d, 2),
       (?e, 1),
       (?g, 2) ] |> Map.fromList
-  Test.label "Multiple scores with multiple letters" <| Test.expect (transform lettersByScore === expected)
+  Test.label "Multiple scores with multiple letters" <| Test.expect (transform lettersByScore == expected)
 
 etl.test.ex4 = let
   lettersByScore = 


### PR DESCRIPTION
Use `==` in tests as it compares the contents of the maps, instead of `===` which is more strict as requires the two objects to be structurally identical, and may fail depending on how the maps were constructed. https://share.unison-lang.org/@unison/p/code/latest/terms/public/base/latest/data/Map/%3D%3D

The following solution was failing on the second test:
```unison
etl.transform : Map Nat [Char] -> Map Char Nat
etl.transform lettersByScore = 
  use Char toLowercase
  fn mp score chars = List.foldLeft (acc ch -> Map.put (toLowercase ch) score acc) mp chars
  Map.foldLeftWithKey fn Map.empty lettersByScore
```