### PR TITLE
Fix test pipeline

### DIFF
--- a/exercises/practice/bowling/.meta/examples/bowling.example.u
+++ b/exercises/practice/bowling/.meta/examples/bowling.example.u
@@ -79,13 +79,13 @@ calculateFrame _ =
       (roll, Some next) | roll + next === 10 -> -- Spare
         completeFrame = Frame currentFrame [roll, next]
         spareScore = !Spare.calculate + 10
-        Tape.right
+        base.ignore Tape.right
         go (currentFrame + 1) (framesSoFar :+ completeFrame) (currentScore + spareScore)
-      (roll, Some next) | (roll + next > 10) || (roll > 10) -> -- validate pin set
+      (roll, Some next) | (roll + next Nat.> 10) || (roll Nat.> 10) -> -- validate pin set
         Throw.throw (Error "Pin count exceeds pins on the lane")
       (roll, Some next) ->
         completeFrame = Frame currentFrame [roll, next]
-        Tape.right
+        base.ignore Tape.right
         go (currentFrame + 1) (framesSoFar :+ completeFrame) (currentScore + roll + next)
       (roll, None) ->
         (framesSoFar, currentScore)
@@ -95,17 +95,17 @@ calculateFrame _ =
 Strike.calculate : '{Tape Nat} Nat
 Strike.calculate _ =
   first = Tape.extract
-  Tape.right
+  base.ignore Tape.right
   second = Tape.extract
   total = first + second
-  Tape.left
+  base.ignore Tape.left
   total
 
 Spare.calculate : '{Tape Nat} Nat
 Spare.calculate _ =
-  Tape.right
+  base.ignore Tape.right
   first = Tape.extract
-  Tape.left
+  base.ignore Tape.left
   first
 
 {{ Represents a frame with a turn number a list for the rolls in the turn }}

--- a/exercises/practice/nucleotide-count/.meta/examples/nucleotideCount.example.u
+++ b/exercises/practice/nucleotide-count/.meta/examples/nucleotideCount.example.u
@@ -3,7 +3,7 @@ nucleotideCounts nucleotides =
   initialMap = [("A",0),("C",0),("G",0),("T",0)] |> Map.fromList
   chars = toCharList nucleotides
   go acc c =
-    if not (List.contains (toText c) (Map.keys initialMap) ) then abort else updateMap c acc
+    if not (List.contains (Char.toText c) (Map.keys initialMap) ) then abort else updateMap c acc
   Abort.toOptional! '(List.foldLeft go initialMap chars)
 
 updateMap : Char -> Map Text Nat -> Map Text Nat

--- a/exercises/practice/raindrops/.meta/examples/raindrops.example.u
+++ b/exercises/practice/raindrops/.meta/examples/raindrops.example.u
@@ -13,4 +13,4 @@ convert n =
   if raindrop then
     List.foldLeft (acc -> cases (bool, sound) -> addSound bool sound acc ) "" [(isThree, "Pling"), (isFive, "Plang"), (isSeven, "Plong")]
   else
-    toText n
+    Nat.toText n

--- a/exercises/practice/stream-ops/.meta/examples/streamOps.example.u
+++ b/exercises/practice/stream-ops/.meta/examples/streamOps.example.u
@@ -4,7 +4,6 @@ MyStream.fromList : [a] -> '{MyStream a} ()
 MyStream.fromList list = 'let
   List.foreach MyStream.emit list
 
-
 MyStream.toList : '{g, MyStream a} r -> '{g} [a]
 MyStream.toList streamFunction = 'let
   at1 !(toListWithResult streamFunction)

--- a/exercises/practice/stream-ops/.meta/examples/streamOps.example.u
+++ b/exercises/practice/stream-ops/.meta/examples/streamOps.example.u
@@ -2,7 +2,7 @@ structural ability MyStream a where emit : a -> {MyStream a} ()
 
 MyStream.fromList : [a] -> '{MyStream a} ()
 MyStream.fromList list = 'let
-  List.foreach MyStream.emit list
+  List.foreach list MyStream.emit
 
 MyStream.toList : '{g, MyStream a} r -> '{g} [a]
 MyStream.toList streamFunction = 'let

--- a/exercises/practice/stream-ops/.meta/examples/streamOps.example.u
+++ b/exercises/practice/stream-ops/.meta/examples/streamOps.example.u
@@ -2,8 +2,8 @@ structural ability MyStream a where emit : a -> {MyStream a} ()
 
 MyStream.fromList : [a] -> '{MyStream a} ()
 MyStream.fromList list = 'let
-  List.map MyStream.emit list
-  ()
+  List.foreach MyStream.emit list
+
 
 MyStream.toList : '{g, MyStream a} r -> '{g} [a]
 MyStream.toList streamFunction = 'let
@@ -49,6 +49,6 @@ MyStream.flatMap f streamFunction = 'let
   go = cases
       { r }                -> r
       {MyStream.emit a -> resume} ->
-        (f a)
+        base.ignore (f a)
         handle resume () with go
   handle !streamFunction with go

--- a/exercises/practice/zebra-puzzle/.meta/examples/zebraPuzzle.example.u
+++ b/exercises/practice/zebra-puzzle/.meta/examples/zebraPuzzle.example.u
@@ -24,7 +24,6 @@ Position.toInt = cases
   Three -> +3
   Four -> +4
   Five -> +5
-  _ -> bug "invalid position"
 
 Position.fromInt : Int -> Position
 Position.fromInt = cases

--- a/exercises/practice/zebra-puzzle/.meta/examples/zebraPuzzle.example.u
+++ b/exercises/practice/zebra-puzzle/.meta/examples/zebraPuzzle.example.u
@@ -24,6 +24,7 @@ Position.toInt = cases
   Three -> +3
   Four -> +4
   Five -> +5
+  _ -> bug "invalid position"
 
 Position.fromInt : Int -> Position
 Position.fromInt = cases
@@ -32,10 +33,11 @@ Position.fromInt = cases
   +3 -> Three
   +4 -> Four
   +5 -> Five
+  _ -> bug "invalid position"
 
 Position.inRange : Int -> Boolean
 Position.inRange i =
-  i <= +5 && (i >= +1)
+  i Int.<= +5 && (i Int.>= +1)
 
 unique type House = { position : Position, color : Color, resident : Resident, beverage : Beverage, cigarette : Cigarette, pet : Pet}
 


### PR DESCRIPTION
Old executable didn't enforce some of our new compiler safety measures, such as compile-time checking of pattern match completeness, and checking that non-unit values don't get discarded. 