### PR TITLE
add-exercise-script-changes: Added usage of the 'configlet create --practice-exercise'.

### DIFF
--- a/bin/add-exercise
+++ b/bin/add-exercise
@@ -7,37 +7,14 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-command -v jq >/dev/null 2>&1 || {
-    echo >&2 "jq is required but not installed. Please install it and make sure it's in your PATH."
-    exit 1
-}
-command -v curl >/dev/null 2>&1 || {
-    echo >&2 "curl is required but not installed. Please install it and make sure it's in your PATH."
-    exit 1
-}
-
 bin/fetch-configlet
 
 # Add entry for exercise in config.json
 slug="${1}"
-name=$(echo "${slug}" | sed 's/\b\w/\u&/g')
-uuid=$(bin/configlet uuid)
-jq --arg slug "${slug}" --arg uuid "${uuid}" --arg name "${name}" \
-    '.exercises.practice += [{slug: $slug, name: $name, uuid: $uuid, practices: [], prerequisites: [], difficulty: 1}]' \
-    config.json > config.json.tmp && mv config.json.tmp config.json
+bin/configlet create --practice-exercise "${slug}"
 
-# Sync the exercise
-bin/configlet sync --update --yes --tests include --filepaths --metadata --docs --exercise "${slug}"
-
-newline=$'\n'
 camel_name=$(sed -E 's/-([a-z])/\U\1/g' <<< "${slug}")
 exercise_dir="exercises/practice/${slug}"
-
-touch "${exercise_dir}/${camel_name}.u"
-touch "${exercise_dir}/${camel_name}.test.u"
-
-mkdir -p "${exercise_dir}/.meta/examples"
-touch "${exercise_dir}/.meta/examples/${camel_name}.example.u"
 
 cat <<EOT > "${exercise_dir}/.meta/testLoader.md"
 # Testing transcript for ${slug} exercise


### PR DESCRIPTION
@rlmark @ErikSchierboom Cleaned `bin/add-exercise` script a little bit and changed the logic of the fetching practice exercise data by using `configlet create --practice-exercise` command.