### PR TITLE
Mark Scale Generator as deprecated

### DIFF
--- a/config.json
+++ b/config.json
@@ -205,7 +205,8 @@
         "uuid": "d83fd7ee-2eff-41d5-8a7c-e3893a969150",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 4
+        "difficulty": 4,
+        "status": "deprecated"
       },
       {
         "slug": "sieve",


### PR DESCRIPTION
This syncs the status update from https://github.com/exercism/problem-specifications/pull/2343