### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/dnd-character/.docs/instructions.append.md
+++ b/exercises/practice/dnd-character/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 There are some important concepts that are necessary for this task:
 

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,6 +1,7 @@
-# Hints
+# Instructions append
+
+## Hints
 
 To complete this exercise, you need to implement the `hello` function.
 
-You will find the type signature for `hello` already in place,
-but it is up to you to define the function.
+You will find the type signature for `hello` already in place, but it is up to you to define the function.

--- a/exercises/practice/majority-element/.docs/instructions.append.md
+++ b/exercises/practice/majority-element/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 - Bonus points: can you generalize your implementation to find the majority element of any type of List?
 - Bonus points: is your implementation performant if there are many different elements to choose from when finding the majority?
 - While you can implement the `majorityFinder` function in any way you choose, we've provided a few stubs which use the `MyStore` ability. (The `MyStore` ability is the same as `Store` from the standard library, but here we've given it a slightly different name for disambiguation.) You'll need to implement the `runWith` handler if you choose to use this ability. `runWith` returns both the result of running the function which uses the `MyStore` ability and the final state of the `MyStore`.

--- a/exercises/practice/matching-brackets/.docs/instructions.append.md
+++ b/exercises/practice/matching-brackets/.docs/instructions.append.md
@@ -1,7 +1,12 @@
 # Instructions append
 
+## Implementation
+
 There are many ways to accomplish this exercise, but we've provided some additional stubs for folks who'd like to practice writing their own [ability handlers][ability-handler-docs].
 
-The signature for the `checkBalance` helper function given for this exercise makes use of an ability requirement, `{Stack}`. The ability `Stack` is defined for you, but the handler, `Stack.run` is not! If you chose, you can implement the `Stack.run`, `checkBalance`, and `isPaired` function. The tests will run even if you choose not to implement this exercise with abilities.
+The signature for the `checkBalance` helper function given for this exercise makes use of an ability requirement, `{Stack}`.
+The ability `Stack` is defined for you, but the handler, `Stack.run` is not!
+If you chose, you can implement the `Stack.run`, `checkBalance`, and `isPaired` function.
+The tests will run even if you choose not to implement this exercise with abilities.
 
 [ability-handler-docs]: https://www.unison-lang.org/learn/fundamentals/abilities/writing-abilities/

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 ~~~~exercism/caution
 Your implementation should not use `Text.reverse`.
 ~~~~

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -1,7 +1,8 @@
 # Instructions append
 
-To complete this exercise, you need to create the data type `LinkedList`,
-and implement the following functions:
+## Implementation
+
+To complete this exercise, you need to create the data type `LinkedList`, and implement the following functions:
 
 - `new`
 - `cons`
@@ -13,5 +14,4 @@ and implement the following functions:
 - `reverseLinkedList`
 - `toList`
 
-You will find a dummy type declaration and type signatures already in place,
-but it is up to you to define the functions and create a meaningful data type.
+You will find a dummy type declaration and type signatures already in place, but it is up to you to define the functions and create a meaningful data type.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.